### PR TITLE
Fix Invalid value for Enddate.

### DIFF
--- a/java/v3.3/src/main/java/com/google/api/services/samples/dfareporting/ads/CreateRotationGroup.java
+++ b/java/v3.3/src/main/java/com/google/api/services/samples/dfareporting/ads/CreateRotationGroup.java
@@ -72,7 +72,7 @@ public class CreateRotationGroup {
     deliverySchedule.setPriority("AD_PRIORITY_01");
 
     DateTime startDate = new DateTime(new Date());
-    DateTime endDate = campaign.getEndDate();
+    DateTime endDate = new DateTime(campaign.getEndDate().getValue());
 
     // Create a rotation group.
     Ad rotationGroup = new Ad();


### PR DESCRIPTION
Running this code gave,
  "code" : 400,
  "errors" : [ {
    "domain" : "global",
    "message" : "Invalid value for: Invalid format: \"2020-05-11\" is too short",
    "reason" : "invalid"
  } ],
  "message" : "Invalid value for: Invalid format: \"2020-05-11\" is too short"
}

Talking to google Team(Sang)  it seemed,
 It appears that the Campaign end date is a date only however the Ad end date requires the date and time to end. Hence the error message is saying its too short as it is missing the time component i.e. its expecting a format like 2020-05-11T16:00:00.000-08:00
 
You can confirm that the Campaign end date is a date only with the following: campaign.getEndDate().isDateOnly() which should return true.
 
To get your sample code working you can replace your line 75 from:
        
    DateTime endDate = campaign.getEndDate();
 
to
 
    DateTime endDate = new DateTime(campaign.getEndDate().getValue());